### PR TITLE
64-bit toolchain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+obj
+libs

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+   <uses-sdk android:minSdkVersion="9" />
+</manifest>

--- a/apps/Android.mk
+++ b/apps/Android.mk
@@ -55,7 +55,7 @@ LOCAL_SRC_FILES:= \
 
 #   cms.c ec.c s_server.c
 
-LOCAL_SHARED_LIBRARIES := \
+LOCAL_STATIC_LIBRARIES := \
 	libssl \
 	libcrypto 
 
@@ -64,6 +64,8 @@ LOCAL_C_INCLUDES := \
 	$(NDK_PROJECT_PATH)/include
 
 LOCAL_CFLAGS := -DMONOLITH
+
+LOCAL_LDLIBS += -lz
 
 include $(LOCAL_PATH)/../android-config.mk
 

--- a/crypto/Android.mk
+++ b/crypto/Android.mk
@@ -501,7 +501,8 @@ ifeq ($(TARGET_SIMULATOR),true)
 endif
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE:= libcrypto
-include $(BUILD_SHARED_LIBRARY)
+#include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)
 
 #######################################
 # host shared library

--- a/default.properties
+++ b/default.properties
@@ -1,2 +1,2 @@
 # Project target.
-target=android-8
+target=android-9

--- a/ssl/Android.mk
+++ b/ssl/Android.mk
@@ -51,7 +51,8 @@ LOCAL_C_INCLUDES += $(local_c_includes)
 LOCAL_SHARED_LIBRARIES += libcrypto
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE:= libssl
-include $(BUILD_SHARED_LIBRARY)
+#include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)
 
 ifeq ($(WITH_HOST_DALVIK),true)
     include $(CLEAR_VARS)
@@ -69,7 +70,8 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/../android-config.mk
 LOCAL_SRC_FILES:= ssltest.c
 LOCAL_C_INCLUDES += $(local_c_includes)
-LOCAL_SHARED_LIBRARIES := libssl libcrypto
+LOCAL_LDLIBS += -lz
+LOCAL_STATIC_LIBRARIES := libssl libcrypto
 LOCAL_MODULE:= ssltest
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
NDK r8e has a 64-bit toolchain available, so I updated the scripts to handle that nicely.

One change was to recognize 'x86_64' as well as 'amd64' when determining `$HOST_ARCH`. The net was to create the platform names as `[value]-$HOST_ARCH` instead of hardcoding `-x86`. The last change was to recognize a toolset name with a `(64-bit)` suffix, although only for NDK r8e. I'm sure a more experienced shell-coding hand than mine can improve on my simple OR statement for that though…
